### PR TITLE
chore: Phase 4 Claude ecosystem - skills, subagent, knowledge graph

### DIFF
--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -29,52 +29,26 @@ This document tracks the progress of the comprehensive tech debt remediation for
 
 ---
 
-## Phase 3: Documentation - IN PROGRESS
+## Phase 3: Documentation - COMPLETED
 
-**GitHub Issue:** [#19](https://github.com/YuvInv/sevanta-uploader/issues/19)
-**Branch:** `docs/tech-debt-phase-3`
+**GitHub Issue:** [#19](https://github.com/YuvInv/sevanta-uploader/issues/19) (Closed)
+**PR:** [#26](https://github.com/YuvInv/sevanta-uploader/pull/26) (Merged)
 
-### Task 3.1: README.md
-- [x] Project overview
-- [x] Installation instructions
-- [x] Usage guide
-- [x] Tech stack badges
-
-### Task 3.2: Create GitHub Templates
-- [x] `.github/ISSUE_TEMPLATE/bug.md`
-- [x] `.github/ISSUE_TEMPLATE/feature.md`
-- [x] `.github/pull_request_template.md`
-
-### Task 3.3: Clean Up GitHub Issues
-- [x] Close Issue #4 (CI/CD already implemented)
-- [x] Sync TODO.md with GitHub Issues
-- [x] Delete Myideas.md (content migrated to issues)
+- [x] README.md with overview, installation, usage, badges
+- [x] GitHub templates (bug, feature, PR)
+- [x] Closed stale Issue #4, synced TODO.md, deleted Myideas.md
 
 ---
 
-## Phase 4: Claude Ecosystem
+## Phase 4: Claude Ecosystem - COMPLETED
 
 **GitHub Issue:** [#20](https://github.com/YuvInv/sevanta-uploader/issues/20)
 **Branch:** `chore/tech-debt-phase-4`
 
-### Task 4.1: Create /sync-todos Skill
-- [ ] Create `~/.claude/skills/sync-todos.md`
-- [ ] Implement bidirectional sync logic
-- [ ] Test with TODO.md and GitHub Issues
-
-### Task 4.2: Create /build-extension Skill
-- [ ] Create `~/.claude/skills/build-extension.md`
-- [ ] Automate npm build + Chrome load instructions
-
-### Task 4.3: Create Extension-Dev Subagent
-- [ ] Create `~/.claude/agents/extension-dev.md`
-- [ ] Specialize for Chrome Extension patterns
-
-### Task 4.4: Populate KNOWLEDGE_GRAPH.md
-- [ ] Add Sevanta API quirks (dbname vs label)
-- [ ] Add project patterns and conventions
-- [ ] Add user preferences learned
-- [ ] Target 10+ meaningful entries
+- [x] Created `/sync-todos` skill (`~/.claude/skills/sync-todos.md`)
+- [x] Created `/build-extension` skill (`~/.claude/skills/build-extension.md`)
+- [x] Created `extension-dev` subagent (`~/.claude/agents/extension-dev.md`)
+- [x] Populated KNOWLEDGE_GRAPH.md with 15+ entries
 
 ---
 
@@ -152,9 +126,15 @@ This document tracks the progress of the comprehensive tech debt remediation for
 - Phase 1: Fixed URLs, added ErrorBoundary, removed console.logs (PR #23 merged)
 - Phase 2: Refactored App.tsx, consolidated API, added 56 tests (PR #24)
 
-### 2026-02-01: Phase 3 Progress
+### 2026-02-01: Phase 3 Completed
 - Created GitHub issue/PR templates
 - Synced TODO.md with GitHub Issues
 - Closed stale Issue #4 (CI/CD complete)
 - Deleted Myideas.md (migrated to issues)
 - Added Phase 6 for UX/performance issues (#25)
+
+### 2026-02-01: Phase 4 Completed
+- Created `/sync-todos` skill for TODO.md ↔ GitHub Issues sync
+- Created `/build-extension` skill for Chrome extension builds
+- Created `extension-dev` subagent for extension development
+- Populated KNOWLEDGE_GRAPH.md with 15+ entries (API quirks, patterns, preferences)


### PR DESCRIPTION
## Summary
Set up Claude Code automation infrastructure for improved development workflow.

## Changes

### New Skills (in ~/.claude/skills/)
- **`/sync-todos`** - Bidirectional sync between TODO.md and GitHub Issues
- **`/build-extension`** - Build Chrome extension and show load instructions

### New Subagent (in ~/.claude/agents/)
- **`extension-dev`** - Chrome Extension development specialist for manifest, content scripts, service workers, message passing

### Knowledge Graph Updates
- Added 15+ entries to KNOWLEDGE_GRAPH.md
- Sevanta API quirks (dbname vs label, rate limits)
- Extension architecture patterns
- User preferences (git workflow, code quality)
- Domain knowledge (VC/CRM, Manifest V3)

## Related Issues
Closes #20

## Test plan
- [x] Skills are properly formatted
- [x] Subagent frontmatter is valid
- [x] KNOWLEDGE_GRAPH.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)