### PR TITLE
ci: combine tag and release into single workflow

### DIFF
--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -1,4 +1,4 @@
-name: Tag on Merge
+name: Tag and Release
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 jobs:
-  create-tag:
+  tag-and-release:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
@@ -41,3 +41,34 @@ jobs:
           git tag ${{ steps.get_version.outputs.VERSION }}
           git push origin ${{ steps.get_version.outputs.VERSION }}
           echo "Created and pushed tag ${{ steps.get_version.outputs.VERSION }}"
+
+      - name: Setup Node.js
+        if: steps.check_tag.outputs.TAG_EXISTS == 'false'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        if: steps.check_tag.outputs.TAG_EXISTS == 'false'
+        run: npm ci
+
+      - name: Build extension
+        if: steps.check_tag.outputs.TAG_EXISTS == 'false'
+        run: npm run build
+
+      - name: Zip extension
+        if: steps.check_tag.outputs.TAG_EXISTS == 'false'
+        run: |
+          cd dist
+          zip -r ../sevanta-uploader-${{ steps.get_version.outputs.VERSION }}.zip .
+          cd ..
+
+      - name: Create Release
+        if: steps.check_tag.outputs.TAG_EXISTS == 'false'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.get_version.outputs.VERSION }}
+          files: sevanta-uploader-${{ steps.get_version.outputs.VERSION }}.zip
+          generate_release_notes: true
+          draft: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sevanta-uploader",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sevanta-uploader",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "papaparse": "^5.4.1",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sevanta-uploader",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Bulk upload companies to Sevanta Dealflow CRM",
   "type": "module",
   "scripts": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sevanta Uploader",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Bulk upload companies to Sevanta Dealflow CRM",
   "permissions": [
     "storage",


### PR DESCRIPTION
## Summary

- Combine tag creation and release creation into a single workflow
- GitHub Actions workflows using the default GITHUB_TOKEN cannot trigger other workflows
- Now when a PR is merged to main, the workflow will:
  1. Create and push a git tag (e.g., v1.0.3)
  2. Build the extension
  3. Create a GitHub release with the zipped extension

## Test plan

- [ ] Merge this PR
- [ ] Verify tag v1.0.3 is created
- [ ] Verify GitHub release v1.0.3 is created with zip artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)