### PR TITLE
fix(dealigence): handle changed React fiber structure for founders extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage/
 *.bak
 .claude/settings.local.json
 *.zip
+.worktrees/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sevanta-uploader",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sevanta-uploader",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "dependencies": {
         "papaparse": "^5.4.1",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sevanta-uploader",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Bulk upload companies to Sevanta Dealflow CRM",
   "type": "module",
   "scripts": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sevanta Uploader",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Bulk upload companies to Sevanta Dealflow CRM",
   "permissions": [
     "storage",

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -330,7 +330,11 @@ async function extractFoundersFromPage(
           .map(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (item: any) => {
-              const props = item.tooltip?.props?.children?.props;
+              const children = item.tooltip?.props?.children;
+              // Handle both single element (old) and array (new Dealigence structure)
+              const props = Array.isArray(children)
+                ? children.find((c: { props?: { name?: string } }) => c?.props?.name)?.props
+                : children?.props;
               if (!props?.name) return null;
               return {
                 name: props.name as string,


### PR DESCRIPTION
## Summary
- Dealigence changed their React component structure — `tooltip.props.children` is now an array instead of a single element
- Updated `extractFoundersFromPage()` to handle both old (single element) and new (array) structures
- Verified via browser observation: 4 founders extracted correctly on `dealigence.vc/company/wiz`

## Test plan
- [x] Load extension from `dist/` in Chrome
- [x] Navigate to `dealigence.vc/company/wiz` (full page load)
- [x] Click Quick Upload — should show 4 founders with names and titles
- [x] Test SPA navigation to another company — founders should still extract

🤖 Generated with [Claude Code](https://claude.com/claude-code)