### PR TITLE
chore: bump version to 2.2.2 for CWS release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sevanta-uploader",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sevanta-uploader",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "dependencies": {
         "papaparse": "^5.4.1",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sevanta-uploader",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Bulk upload companies to Sevanta Dealflow CRM",
   "type": "module",
   "scripts": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Sevanta Uploader",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Bulk upload companies to Sevanta Dealflow CRM",
   "permissions": [
     "storage",


### PR DESCRIPTION
## Summary
- Chrome Web Store already had 2.2.1 published, so the release CI for #88 failed with `PKG_INVALID_VERSION_NUMBER`
- Bumps to 2.2.2 to trigger a successful release

🤖 Generated with [Claude Code](https://claude.com/claude-code)